### PR TITLE
feat: add user auth and session management

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,15 +1,22 @@
 import { Env } from './utils/credits';
 
-export const onRequest: PagesFunction<Env> = async ({ request, next }) => {
+export const onRequest: PagesFunction<Env> = async ({ request, env, next }) => {
   const cookie = request.headers.get('cookie') || '';
-  if (!/uid=/.test(cookie)) {
-    const uid = crypto.randomUUID();
-    const res = await next();
-    res.headers.append(
-      'Set-Cookie',
-      `uid=${uid}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=31536000`,
-    );
-    return res;
+  const sid = cookie.match(/sid=([^;]+)/)?.[1];
+  if (sid) {
+    const uid = await env.CREDITS_KV.get(`session:${sid}`);
+    if (uid) {
+      request.headers.set('x-user-id', uid);
+      await env.CREDITS_KV.put(`session:${sid}`, uid, {
+        expirationTtl: 60 * 60 * 24,
+      });
+      const res = await next();
+      res.headers.append(
+        'Set-Cookie',
+        `sid=${sid}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=86400`,
+      );
+      return res;
+    }
   }
   return next();
 };

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -1,0 +1,34 @@
+import { Env } from '../utils/credits';
+
+export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
+  const { username, password } = await request.json<{
+    username: string;
+    password: string;
+  }>();
+  if (!username || !password) {
+    return new Response('bad request', { status: 400 });
+  }
+  const stored = await env.CREDITS_KV.get(`user:${username}`);
+  if (!stored) {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const buf = new TextEncoder().encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buf);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hash = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  if (hash !== stored) {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const sid = crypto.randomUUID();
+  await env.CREDITS_KV.put(`session:${sid}`, username, {
+    expirationTtl: 60 * 60 * 24,
+  });
+  const res = new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  res.headers.append(
+    'Set-Cookie',
+    `sid=${sid}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=86400`,
+  );
+  return res;
+};

--- a/functions/api/me-credits.ts
+++ b/functions/api/me-credits.ts
@@ -1,10 +1,12 @@
 import { Env, getCredits } from '../utils/credits';
 
-const uidFrom = (req: Request) =>
-  (req.headers.get('cookie') || '').match(/uid=([^;]+)/)?.[1] || '';
+const userIdFrom = (req: Request) => req.headers.get('x-user-id') || '';
 
 export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
-  const uid = uidFrom(request);
+  const uid = userIdFrom(request);
+  if (!uid) {
+    return new Response('unauthorized', { status: 401 });
+  }
   const credits = await getCredits(env, uid);
   return new Response(JSON.stringify({ uid, credits }), {
     headers: { 'Content-Type': 'application/json' },

--- a/functions/api/register.ts
+++ b/functions/api/register.ts
@@ -1,0 +1,26 @@
+import { Env } from '../utils/credits';
+
+export const onRequest: PagesFunction<Env> = async ({ request, env }) => {
+  const { username, password } = await request.json<{
+    username: string;
+    password: string;
+  }>();
+  if (!username || !password) {
+    return new Response('bad request', { status: 400 });
+  }
+  const exists = await env.CREDITS_KV.get(`user:${username}`);
+  if (exists) {
+    return new Response(
+      JSON.stringify({ error: 'user exists', code: 'error_user_exists' }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+  const buf = new TextEncoder().encode(password);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', buf);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const hash = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+  await env.CREDITS_KV.put(`user:${username}`, hash);
+  return new Response(JSON.stringify({ ok: true }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+};

--- a/functions/utils/credits.ts
+++ b/functions/utils/credits.ts
@@ -7,28 +7,28 @@ export interface Env {
   STRIPE_WEBHOOK_SECRET: string;
 }
 
-const key = (uid: string) => `credits:${uid}`;
+const key = (userId: string) => `credits:${userId}`;
 
-export async function getCredits(env: Env, uid: string): Promise<number> {
-  const val = await env.CREDITS_KV.get(key(uid));
+export async function getCredits(env: Env, userId: string): Promise<number> {
+  const val = await env.CREDITS_KV.get(key(userId));
   return val ? Number(val) : 0;
 }
 
 export async function addCredits(
   env: Env,
-  uid: string,
+  userId: string,
   delta: number,
 ): Promise<number> {
-  const curr = await getCredits(env, uid);
+  const curr = await getCredits(env, userId);
   const next = curr + delta;
-  await env.CREDITS_KV.put(key(uid), String(next));
+  await env.CREDITS_KV.put(key(userId), String(next));
   return next;
 }
 
-export async function consumeCredit(env: Env, uid: string): Promise<number> {
-  const curr = await getCredits(env, uid);
+export async function consumeCredit(env: Env, userId: string): Promise<number> {
+  const curr = await getCredits(env, userId);
   if (curr < 1) throw new Error('NO_CREDITS');
   const next = curr - 1;
-  await env.CREDITS_KV.put(key(uid), String(next));
+  await env.CREDITS_KV.put(key(userId), String(next));
   return next;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import ResultViewer from './components/ResultViewer';
 import LanguageSwitcher from './components/LanguageSwitcher';
 import CreditBadge from './components/CreditBadge';
 import BuyCreditsButton from './components/BuyCreditsButton';
+import LoginForm from './components/LoginForm';
+import RegisterForm from './components/RegisterForm';
 import * as api from './lib/api';
 import { Pack } from './lib/types';
 
@@ -14,12 +16,16 @@ const App: React.FC = () => {
   const [orig, setOrig] = useState<string | null>(null);
   const [edited, setEdited] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [loggedIn, setLoggedIn] = useState(false);
 
   useEffect(() => {
     api
       .getMeCredits()
-      .then((r) => setCredits(r.credits))
-      .catch(() => {});
+      .then((r) => {
+        setCredits(r.credits);
+        setLoggedIn(true);
+      })
+      .catch(() => setLoggedIn(false));
   }, []);
 
   const onEdit = async (file: File, prompt: string) => {
@@ -54,6 +60,26 @@ const App: React.FC = () => {
             <LanguageSwitcher />
           </div>
           <p>{path === '/success' ? t('go_to_checkout') : t('cancel')}</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!loggedIn) {
+    const refresh = async () => {
+      const r = await api.getMeCredits();
+      setCredits(r.credits);
+      setLoggedIn(true);
+    };
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="w-full max-w-md space-y-4 rounded-xl bg-white p-6 shadow-lg">
+          <div className="flex items-center justify-between">
+            <h1 className="text-3xl font-bold">{t('title')}</h1>
+            <LanguageSwitcher />
+          </div>
+          <LoginForm onLoggedIn={refresh} />
+          <RegisterForm onRegistered={refresh} />
         </div>
       </div>
     );

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import * as api from '../lib/api';
+
+interface Props {
+  onLoggedIn: () => void;
+}
+
+const LoginForm: React.FC<Props> = ({ onLoggedIn }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await api.login(username, password);
+      onLoggedIn();
+    } catch {
+      setError('login failed');
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      {error && <div className="text-sm text-red-500">{error}</div>}
+      <input
+        className="w-full border p-2"
+        placeholder="Username"
+        value={username}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setUsername(e.target.value)
+        }
+      />
+      <input
+        type="password"
+        className="w-full border p-2"
+        placeholder="Password"
+        value={password}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setPassword(e.target.value)
+        }
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        Login
+      </button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/src/components/RegisterForm.tsx
+++ b/src/components/RegisterForm.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import * as api from '../lib/api';
+
+interface Props {
+  onRegistered: () => void;
+}
+
+const RegisterForm: React.FC<Props> = ({ onRegistered }) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      await api.register(username, password);
+      await api.login(username, password);
+      onRegistered();
+    } catch {
+      setError('register failed');
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit} className="space-y-2">
+      {error && <div className="text-sm text-red-500">{error}</div>}
+      <input
+        className="w-full border p-2"
+        placeholder="Username"
+        value={username}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setUsername(e.target.value)
+        }
+      />
+      <input
+        type="password"
+        className="w-full border p-2"
+        placeholder="Password"
+        value={password}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          setPassword(e.target.value)
+        }
+      />
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        Register
+      </button>
+    </form>
+  );
+};
+
+export default RegisterForm;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -36,3 +36,27 @@ export async function edit(image: File, prompt: string): Promise<Blob> {
   }
   return res.blob();
 }
+
+export async function register(
+  username: string,
+  password: string,
+): Promise<void> {
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  await handleJson<unknown>(res);
+}
+
+export async function login(
+  username: string,
+  password: string,
+): Promise<void> {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password }),
+  });
+  await handleJson<unknown>(res);
+}


### PR DESCRIPTION
## Summary
- add registration and login APIs storing hashed credentials and issuing session cookies
- check sessions in middleware and link credits to user IDs
- show login/registration UI and gate app by authenticated state

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b260101e488325af0e19ac72e642b3