### PR TITLE
chore: configure wrangler for worker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "image-edit-app",
   "private": true,
   "scripts": {
-    "dev": "wrangler pages dev -- npm run vite-dev",
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
     "vite-dev": "vite",
     "build": "vite build",
     "preview": "vite preview",

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,9 @@
 name = "image-edit-app"
-main = "src/worker.ts"
+main = "dist/worker.js"
 compatibility_date = "2024-04-05"
+
+[site]
+bucket = "./dist"
 
 [[kv_namespaces]]
 binding = "CREDITS_KV"


### PR DESCRIPTION
## Summary
- point Wrangler to the built worker and static site output
- add npm scripts for `wrangler dev` and `wrangler deploy`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b27982883c83258d26009b4260708a