### PR TITLE
chore: point wrangler site bucket to dist

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ main = "dist/worker.js"
 compatibility_date = "2024-04-05"
 
 [site]
-bucket = "./dist"
+bucket = "dist"
 
 [[kv_namespaces]]
 binding = "CREDITS_KV"


### PR DESCRIPTION
## Summary
- update wrangler.toml to deploy static assets from `dist`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `npx wrangler dev src/worker.ts --port=8787`
- `curl -s -D - -H 'x-user-id: alice' http://127.0.0.1:8787/api/me-credits`
- `npx wrangler deploy src/worker.ts` *(fails: In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work)*

------
https://chatgpt.com/codex/tasks/task_b_68b27a81d27c8325bf3ac6504b108ef9