### PR TITLE
chore: set deployment name to banana

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,4 @@
-name = "image-edit-app"
+name = "banana"
 main = "src/worker.ts"
 compatibility_date = "2024-04-05"
 


### PR DESCRIPTION
## Summary
- rename wrangler project to `banana`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx wrangler deploy` *(fails: requires CLOUDFLARE_API_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_b_68b2a8ed06b883259fab32c096fe8df5