### PR TITLE
chore: update credits kv namespace ids

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,5 +7,5 @@ bucket = "dist"
 
 [[kv_namespaces]]
 binding = "CREDITS_KV"
-id = "local"
-preview_id = "local"
+id = "5a4fb269ece1409b8ec1da3fbdf6e983"
+preview_id = "5a4fb269ece1409b8ec1da3fbdf6e983"


### PR DESCRIPTION
## Summary
- use real Cloudflare KV namespace id for CREDITS_KV in wrangler.toml

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npx wrangler deploy` *(fails: In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_b_68b2a9c29fe08325a52f76e15bc92483