### PR TITLE
fix: configure static asset binding

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -2,8 +2,8 @@ name = "banana"
 main = "src/worker.ts"
 compatibility_date = "2024-04-05"
 
-[site]
-bucket = "dist"
+[assets]
+directory = "dist"
 
 [[kv_namespaces]]
 binding = "CREDITS_KV"


### PR DESCRIPTION
## Summary
- switch wrangler config from `[site]` to `[assets]` so static files are bound as `ASSETS`

## Testing
- `npm run build`
- `npx wrangler dev --port 8790` & `curl http://localhost:8790/`


------
https://chatgpt.com/codex/tasks/task_b_68b2aee4e3a48325a8493dad88c2e06d