### PR TITLE
feat: add project intro on login

### DIFF
--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1,6 +1,7 @@
 {
   "title": "Image Editor",
   "subtitle": "Edit images with AI",
+  "intro": "This app uses the Gemini API to edit images.",
   "upload_image": "Upload Image",
   "enter_prompt": "Enter prompt",
   "start_editing": "Start Editing",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -1,6 +1,7 @@
 {
   "title": "画像エディタ",
   "subtitle": "AIで画像を編集",
+  "intro": "このアプリは Gemini API を使って画像を編集します。",
   "upload_image": "画像をアップロード",
   "enter_prompt": "プロンプトを入力",
   "start_editing": "編集開始",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -1,6 +1,7 @@
 {
   "title": "图像编辑",
   "subtitle": "使用 AI 编辑图像",
+  "intro": "该项目使用 Gemini API 来编辑图片。",
   "upload_image": "上传图片",
   "enter_prompt": "输入提示",
   "start_editing": "开始编辑",

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -24,6 +24,7 @@ const LoginPage: React.FC<Props> = ({ onLoggedIn }) => {
           <h1 className="text-3xl font-bold">{t('title')}</h1>
           <LanguageSwitcher />
         </div>
+        <p className="text-gray-600">{t('intro')}</p>
         <LoginForm onLoggedIn={handleLoggedIn} />
         <Link to="/register" className="text-sm text-blue-600 underline">
           Go register


### PR DESCRIPTION
## Summary
- show a short introduction on the login page about using Gemini API for image editing
- localize the introduction in English, Chinese, and Japanese

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_b_68b2b0a7ed20832583e6bcb2db1e42b6